### PR TITLE
「鋭さ」パラメーターを追加

### DIFF
--- a/Editor/CustomInspector.cs
+++ b/Editor/CustomInspector.cs
@@ -20,6 +20,7 @@ namespace KusakaFactory.LiltoonMsdfMask
         private MaterialProperty _useMsdfMaskEmission2;
         private MaterialProperty _useMsdfMaskMatCap1;
         private MaterialProperty _useMsdfMaskMatCap2;
+        private MaterialProperty _msdfSteepness;
         private MaterialProperty _layeredSdfMode;
         private MaterialProperty _layeredSdfColorR;
         private MaterialProperty _layeredSdfColorG;
@@ -74,6 +75,7 @@ namespace KusakaFactory.LiltoonMsdfMask
             _useMsdfMaskEmission2 = FindProperty("_CustomUseMsdfMaskEmission2", props);
             _useMsdfMaskMatCap1 = FindProperty("_CustomUseMsdfMaskMatCap1", props);
             _useMsdfMaskMatCap2 = FindProperty("_CustomUseMsdfMaskMatCap2", props);
+            _msdfSteepness = FindProperty("_CustomMsdfSteepness", props);
             _layeredSdfMode = FindProperty("_CustomLayeredSdfMode", props);
             _layeredSdfColorR = FindProperty("_CustomLayeredSdfColorR", props);
             _layeredSdfColorG = FindProperty("_CustomLayeredSdfColorG", props);
@@ -139,6 +141,8 @@ namespace KusakaFactory.LiltoonMsdfMask
                 m_MaterialEditor.ShaderProperty(_useMsdfMaskEmission2, _modeLabelEmission2);
                 m_MaterialEditor.ShaderProperty(_useMsdfMaskMatCap1, _modeLabelMatCap1);
                 m_MaterialEditor.ShaderProperty(_useMsdfMaskMatCap2, _modeLabelMatCap2);
+
+                lilEditorGUI.LocalizedProperty(m_MaterialEditor, _msdfSteepness, false);
 
                 EditorGUILayout.EndVertical();
                 EditorGUILayout.EndVertical();

--- a/Editor/strings.tsv
+++ b/Editor/strings.tsv
@@ -10,3 +10,4 @@ scMMLSModes	Layered SDF	マルチレイヤー SDF	Layered SDF	Layered SDF	Layere
 scMMLSColorR	Channel R	R チャンネル	Channel R	Channel R	Channel R
 scMMLSColorG	Channel G	G チャンネル	Channel G	Channel G	Channel G
 scMMLSColorB	Channel B	B チャンネル	Channel B	Channel B	Channel B
+scMMSteepness	Steepness	鋭さ	Steepness	Steepness	Steepness

--- a/Shader/custom.hlsl
+++ b/Shader/custom.hlsl
@@ -13,6 +13,7 @@
     int _CustomUseMsdfMaskEmission2; \
     int _CustomUseMsdfMaskMatCap1;   \
     int _CustomUseMsdfMaskMatCap2;   \
+    float _CustomMsdfSteepness;      \
     \
     int _CustomLayeredSdfMode;       \
     float4 _CustomLayeredSdfColorR;  \
@@ -30,7 +31,7 @@
 #define OVERRIDE_SHADOW lilGetShadingMsdfMask(fd LIL_SAMP_IN(sampler_MainTex));
 #define OVERRIDE_MATCAP lilGetMatCapMsdfMask(fd LIL_SAMP_IN(sampler_MainTex));
 #define OVERRIDE_MATCAP2ND lilGetMatCap2ndMsdfMask(fd LIL_SAMP_IN(sampler_MainTex));
-#if !defined(LIL_LITE) 
+#if !defined(LIL_LITE)
     #define OVERRIDE_EMISSION_1ST lilEmissionMsdfMask(fd LIL_SAMP_IN(sampler_MainTex));
     #define OVERRIDE_EMISSION_2ND lilEmission2ndMsdfMask(fd LIL_SAMP_IN(sampler_MainTex));
 #endif

--- a/Shader/custom_insert.hlsl
+++ b/Shader/custom_insert.hlsl
@@ -2,6 +2,13 @@ float4 lilMsdfMaskSDF(float4 input) {
     return step(float4(0.5, 0.5, 0.5, 0.5), input);
 }
 
+float lilMsdfMaskCalculateMSDF(float3 msd, float steepness) {
+    float sd = lilMedian(msd.r, msd.g, msd.b);
+    float smoothRange = (1.0 - steepness) * 0.01;
+    return smoothstep(0.5 - smoothRange, 0.5 + smoothRange, sd);
+    // return saturate((sd - 0.5) / clamp(fwidth(sd), 0.01, 1.0));
+}
+
 float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
     float alpha = lerp(bg.a, 1.0, fg.a);
     float3 color = lerp(bg.rgb * bg.a, fg.rgb, fg.a) / max(alpha, 0.001);
@@ -16,8 +23,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
         {
             float4 maskColor = LIL_SAMPLE_2D_ST(_AlphaMask, sampler_MainTex, fd.uvMain);
             float maskValue = maskColor.r;
-            if (_CustomUseMsdfMaskAlpha == 1) maskValue = lilMSDF(maskColor.rgb) * maskColor.a;
-            if (_CustomUseMsdfMaskAlpha == 2) maskValue = 1.0 - lilMSDF(maskColor.rgb) * maskColor.a;
+            if (_CustomUseMsdfMaskAlpha == 1) maskValue = lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
+            if (_CustomUseMsdfMaskAlpha == 2) maskValue = 1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
 
             float alphaMask = saturate(maskValue * _AlphaMaskScale + _AlphaMaskValue);
             if(_AlphaMaskMode == 1) fd.col.a = alphaMask;
@@ -30,8 +37,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
         {
             float4 maskColor2 = LIL_SAMPLE_2D_ST(_CustomAlphaMask2nd, sampler_MainTex, fd.uvMain);
             float maskValue2 = maskColor2.r;
-            if (_CustomUseMsdfMaskAlpha2 == 1) maskValue2 = lilMSDF(maskColor2.rgb) * maskColor2.a;
-            if (_CustomUseMsdfMaskAlpha2 == 2) maskValue2 = 1.0 - lilMSDF(maskColor2.rgb) * maskColor2.a;
+            if (_CustomUseMsdfMaskAlpha2 == 1) maskValue2 = lilMsdfMaskCalculateMSDF(maskColor2.rgb, _CustomMsdfSteepness) * maskColor2.a;
+            if (_CustomUseMsdfMaskAlpha2 == 2) maskValue2 = 1.0 - lilMsdfMaskCalculateMSDF(maskColor2.rgb, _CustomMsdfSteepness) * maskColor2.a;
 
             float alphaMask2 = saturate(maskValue2 * _CustomAlphaMask2ndScale + _CustomAlphaMask2ndValue);
             if(_CustomAlphaMask2ndMode == 1) fd.col.a = alphaMask2;
@@ -83,8 +90,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                 // MSDF Mask Process
                 float4 maskColor = LIL_SAMPLE_2D(_Main2ndBlendMask, samp, fd.uvMain);
                 float maskValue = maskColor.r;
-                if (_CustomUseMsdfMaskMain2 == 1) maskValue = lilMSDF(maskColor.rgb) * maskColor.a;
-                if (_CustomUseMsdfMaskMain2 == 2) maskValue = 1.0 - lilMSDF(maskColor.rgb) * maskColor.a;
+                if (_CustomUseMsdfMaskMain2 == 1) maskValue = lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
+                if (_CustomUseMsdfMaskMain2 == 2) maskValue = 1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
                 color2nd.a *= maskValue;
             #endif
 
@@ -188,8 +195,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                 // MSDF Mask Process
                 float4 maskColor = LIL_SAMPLE_2D(_Main3rdBlendMask, samp, fd.uvMain);
                 float maskValue = maskColor.r;
-                if (_CustomUseMsdfMaskMain3 == 1) maskValue = lilMSDF(maskColor.rgb) * maskColor.a;
-                if (_CustomUseMsdfMaskMain3 == 2) maskValue = 1.0 - lilMSDF(maskColor.rgb) * maskColor.a;
+                if (_CustomUseMsdfMaskMain3 == 1) maskValue = lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
+                if (_CustomUseMsdfMaskMain3 == 2) maskValue = 1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
                 color3rd.a *= maskValue;
             #endif
 
@@ -399,8 +406,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                     lnFlat *= lerp(1.0, calculatedShadow, _ShadowReceive);
                 #endif
                 float strengthValue = shadowStrengthMask.r;
-                if (_CustomUseMsdfMaskShadow == 1) strengthValue = lilMSDF(shadowStrengthMask.rgb) * shadowStrengthMask.a;
-                if (_CustomUseMsdfMaskShadow == 2) strengthValue = 1.0 - lilMSDF(shadowStrengthMask.rgb) * shadowStrengthMask.a;
+                if (_CustomUseMsdfMaskShadow == 1) strengthValue = lilMsdfMaskCalculateMSDF(shadowStrengthMask.rgb, _CustomMsdfSteepness) * shadowStrengthMask.a;
+                if (_CustomUseMsdfMaskShadow == 2) strengthValue = 1.0 - lilMsdfMaskCalculateMSDF(shadowStrengthMask.rgb, _CustomMsdfSteepness) * shadowStrengthMask.a;
                 lns = lerp(lnFlat, lns, strengthValue);
             }
             else
@@ -530,8 +537,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                 // MSDF Mask Process
                 float4 maskColor = LIL_SAMPLE_2D_ST(_MatCapBlendMask, samp, fd.uvMain);
                 float3 maskValue = maskColor.rgb;
-                if (_CustomUseMsdfMaskMatCap1 == 1) maskValue = lilMSDF(maskColor.rgb) * maskColor.a;
-                if (_CustomUseMsdfMaskMatCap1 == 2) maskValue = 1.0 - lilMSDF(maskColor.rgb) * maskColor.a;
+                if (_CustomUseMsdfMaskMatCap1 == 1) maskValue = lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
+                if (_CustomUseMsdfMaskMatCap1 == 2) maskValue = 1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
                 matCapMask = maskValue;
             #endif
 
@@ -589,8 +596,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                 // MSDF Mask Process
                 float4 maskColor = LIL_SAMPLE_2D_ST(_MatCap2ndBlendMask, samp, fd.uvMain);
                 float3 maskValue = maskColor.rgb;
-                if (_CustomUseMsdfMaskMatCap2 == 1) maskValue = lilMSDF(maskColor.rgb) * maskColor.a;
-                if (_CustomUseMsdfMaskMatCap2 == 2) maskValue = 1.0 - lilMSDF(maskColor.rgb) * maskColor.a;
+                if (_CustomUseMsdfMaskMatCap2 == 1) maskValue = lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
+                if (_CustomUseMsdfMaskMatCap2 == 2) maskValue = 1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a;
                 matCapMask = maskValue;
             #endif
 
@@ -635,8 +642,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                     float4 maskColor = LIL_SAMPLE_2D_ST(_EmissionBlendMask, samp, fd.uvMain);
                 #endif
                 float4 maskValue = maskColor.rgba;
-                if (_CustomUseMsdfMaskEmission1 == 1) maskValue = float4((lilMSDF(maskColor.rgb) * maskColor.a).xxx, 1.0);
-                if (_CustomUseMsdfMaskEmission1 == 2) maskValue = float4((1.0 - lilMSDF(maskColor.rgb) * maskColor.a).xxx, 1.0);
+                if (_CustomUseMsdfMaskEmission1 == 1) maskValue = float4((lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a).xxx, 1.0);
+                if (_CustomUseMsdfMaskEmission1 == 2) maskValue = float4((1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a).xxx, 1.0);
                 emissionColor *= maskValue;
             #endif
             // Gradation
@@ -699,8 +706,8 @@ float4 lilMsdfMaskAlphaBlend(float4 bg, float4 fg) {
                     float4 maskColor = LIL_SAMPLE_2D_ST(_Emission2ndBlendMask, samp, fd.uvMain);
                 #endif
                 float4 maskValue = maskColor.rgba;
-                if (_CustomUseMsdfMaskEmission2 == 1) maskValue = float4((lilMSDF(maskColor.rgb) * maskColor.a).xxx, 1.0);
-                if (_CustomUseMsdfMaskEmission2 == 2) maskValue = float4((1.0 - lilMSDF(maskColor.rgb) * maskColor.a).xxx, 1.0);
+                if (_CustomUseMsdfMaskEmission2 == 1) maskValue = float4((lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a).xxx, 1.0);
+                if (_CustomUseMsdfMaskEmission2 == 2) maskValue = float4((1.0 - lilMsdfMaskCalculateMSDF(maskColor.rgb, _CustomMsdfSteepness) * maskColor.a).xxx, 1.0);
                 emission2ndColor *= maskValue;
             #endif
             // Gradation

--- a/Shader/lilCustomShaderProperties.lilblock
+++ b/Shader/lilCustomShaderProperties.lilblock
@@ -15,6 +15,7 @@
         [lilEnum] _CustomUseMsdfMaskEmission2 ("scMMEmission2nd", Int) = 0
         [lilEnum] _CustomUseMsdfMaskMatCap1 ("scMMMatCap1st", Int) = 0
         [lilEnum] _CustomUseMsdfMaskMatCap2 ("scMMMatCap2nd", Int) = 0
+        _CustomMsdfSteepness ("scMMSteepness", Range(0, 1.0)) = 0.75
 
         [lilEnum] _CustomLayeredSdfMode ("scMMLSModes", Int) = 0
         [lilHDR] _CustomLayeredSdfColorR ("scMMLSColorR", Color) = (0.0, 0.0, 0.0, 0.0)


### PR DESCRIPTION
UV 密度が極めて低くなる場合に境界部分が階段状になる問題があるため、これを解消するための鋭さパラメーターを追加。

fwidth を参照する代わりに smoothstep の幅をパラメーターで変更するようにし、 steepness = 1 のときは step() 関数と同等になる。